### PR TITLE
Add testing infrastructure and refactor

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,29 @@
+"""
+Tests for `app.py`.
+"""
+
+# pylint: disable=import-error
+
+import unittest
+
+from text_support.app import app
+
+class AppTestCase(unittest.TestCase):
+    """
+    Overarching test cases for the application. Most of the actual testing will
+    occur in `test_views.py` or `test_models.py` as we test the handling of web
+    requests/working with the database.
+    """
+    def setUp(self):
+        """
+        Setup to be run before everytest.
+        """
+        self.app = app.test_client()
+        self.app.testing = True
+
+    def test_app_creation(self):
+        """
+        This test simply checks our blueprints were successfully registered and
+        all configuration occured properly.
+        """
+        self.assertNotEqual(self.app, None)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,38 @@
+"""
+Tests for `views.py`.
+"""
+
+# pylint: disable=import-error
+
+import unittest
+
+# We register our views as a blueprint with `app` in `app.py`, so it is that app
+# we run tests on. See more details
+# [here](http://flask.pocoo.org/docs/0.11/blueprints/).
+from text_support.app import app
+
+class AppViewsTestCase(unittest.TestCase):
+    """
+    Test the views within the application.
+
+    All tests of views will inherit from this class.
+    """
+    def setUp(self):
+        """
+        Setup to be run before everytest.
+        """
+        self.app = app.test_client()
+        self.app.testing = True
+
+class IndexTestCase(AppViewsTestCase):
+    """
+    Test accessing the index route ("/").
+    """
+    def test_index_success(self):
+        """
+        Test a request to `/` is successful (i.e. returns the status code 200).
+        """
+        index_url = "/"
+        result = self.app.get(index_url)
+
+        self.assertEqual(result.status_code, 200)

--- a/text_support/app.py
+++ b/text_support/app.py
@@ -6,12 +6,9 @@
 
 from flask import Flask
 
-app = Flask(__name__)
+from .views import app_views
 
-@app.route("/")
-def hello():
-    """
-    A simple function to render "Hello World" and status code 200 when the `/`
-    endpoint is accessed. Just for testing purposes.
-    """
-    return "Hello World!"
+# Create the flask application and instruct it to use all of the views (routes
+# with associated functions) defined in `app_views` in `views.py`.
+app = Flask(__name__)
+app.register_blueprint(app_views)

--- a/text_support/views.py
+++ b/text_support/views.py
@@ -1,3 +1,20 @@
 """
 `views.py` is where we define the routes of this application.
 """
+
+# pylint: disable=import-error, invalid-name
+
+from flask import Blueprint
+
+# We define `app_views` as a Blueprint so that we can import the views in
+# `app.py`. This allows all of the `view` logic to be stored in a single file.
+# Read more [here](http://flask.pocoo.org/docs/0.11/blueprints/).
+app_views = Blueprint('app_views', __name__)
+
+@app_views.route("/")
+def index():
+    """
+    A simple function to render "Hello World" and status code 200 when the `/`
+    endpoint is accessed. Just for testing purposes.
+    """
+    return "Hello World!"


### PR DESCRIPTION
This commit adds the infrastructure we will use for testing, and writes
a few simple tests of basic routes to check its working properly.

Additionally, we move all of the routes over to `views.py` using
`flask.Blueprint`, in order to split the code into smaller components.
The written tests reflect this change.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>