### PR TITLE
Render index.html

### DIFF
--- a/text_support/templates/index.html
+++ b/text_support/templates/index.html
@@ -5,4 +5,9 @@ will have both a `layout.html` and an `index.html` page like [this
 example](https://github.com/pallets/flask/tree/master/examples/flaskr/templates).
 
 -->
-<h1>Hello World!</h1>
+
+{% extends "layout.html" %}
+
+{% block body %}
+<h1>Welcome to Text Support</h1>
+{% endblock %}

--- a/text_support/templates/layout.html
+++ b/text_support/templates/layout.html
@@ -1,0 +1,11 @@
+<!doctype html>
+
+<title>Text Support</title>
+<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}">
+
+<div class="page">
+  {% for message in get_flashed_messages() %}
+    <div class="flash">{{ message }}</div>
+  {% endfor %}
+  {% block body %}{% endblock %}
+</div>

--- a/text_support/views.py
+++ b/text_support/views.py
@@ -4,7 +4,7 @@
 
 # pylint: disable=import-error, invalid-name
 
-from flask import Blueprint
+from flask import Blueprint, render_template
 
 # We define `app_views` as a Blueprint so that we can import the views in
 # `app.py`. This allows all of the `view` logic to be stored in a single file.
@@ -14,7 +14,9 @@ app_views = Blueprint('app_views', __name__)
 @app_views.route("/")
 def index():
     """
-    A simple function to render "Hello World" and status code 200 when the `/`
-    endpoint is accessed. Just for testing purposes.
+    Render `templates/index.html` with a status code of 200.
+
+    Returns:
+        object: The rendered template.
     """
-    return "Hello World!"
+    return render_template("index.html")


### PR DESCRIPTION
Use the `render_template` method to render `index.html` when a request
is made. Additionally, create the `layout.html` page which all other
pages will extend.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>