### PR TITLE
Reorganize texting functionality

### DIFF
--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,23 @@
+"""
+Tests for `text.py`.
+"""
+
+# pylint: disable=import-error
+
+import unittest
+
+from text_support.text import get_response
+
+class GetResponseTestCase(unittest.TestCase):
+    """
+    Tests for the `views:get_response` method which given the texter's input,
+    determines what we will respond.
+    """
+    def test_sample_test(self):
+        """
+        This is just a sample test to serve as a template..
+
+        @TODO Delete and replace with other tests.
+        """
+        message = "test"
+        self.assertEqual(message, get_response(message))

--- a/text_support/text.py
+++ b/text_support/text.py
@@ -1,0 +1,17 @@
+"""
+`text.py` is where we contain classes and functions related to texting with the
+user.
+"""
+
+def get_response(message):
+    """
+    Given what the texter has sent to us, determine our response.
+
+    Args:
+        message (str): The message the texter has sent to us.
+
+    Response:
+        str: The response we will text back to them.
+    """
+    # @TODO Fill this function in with code that will have respond.
+    return message

--- a/text_support/views.py
+++ b/text_support/views.py
@@ -6,6 +6,8 @@
 
 from flask import Blueprint, render_template, request, Response
 
+from .text import get_response
+
 # We define `static_views` as a Blueprint so that we can import the views in
 # `app.py`. This allows all of the `view` logic to be stored in a single file.
 # Read more [here](http://flask.pocoo.org/docs/0.11/blueprints/).
@@ -55,16 +57,3 @@ def webhook():
     # just wraps around Twilio.
 
     return Response(status=200)
-
-def get_response(message):
-    """
-    Given what the texter has sent to us, determine our response.
-
-    Args:
-        message (str): The message the texter has sent to us.
-
-    Response:
-        str: The response we will text back to them.
-    """
-    # @TODO Fill this function in with code that will have respond.
-    return message


### PR DESCRIPTION
Break out the texting functionality from `views.py` into its own
separate file. Additionally, provide an example of how tests can work.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>