### PR TITLE
Use single python version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   - SECRET_KEY=jklwefa209aergnjaflkmwaeoi
   - DATABASE_URL=postgres://postgres:localhost:5432/postgres
 python:
-- '3.4'
 - '3.5'
 install:
 - pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.5
 
 MAINTAINER mattjmcnaughton@gmail.com
 


### PR DESCRIPTION
Since we are controlling the python version we use on Heroku, we only
need to test one version on travis. We also specify that version on
Docker.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>