### PR TITLE
Add New Relic in production

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn text_support:app --log-file -
+web: newrelic-admin run-program gunicorn text_support:app --log-file -

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pylint==1.*
 psycopg2==2.*
 simplejson==3.*
 twilio==5.*
+newrelic==2.*


### PR DESCRIPTION
Fix #9 

We will use New Relic both for application statistics and also to send a
request to our application every minute so the dyno does not power down.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>