### PR TITLE
Add command to force follow up texts

### DIFF
--- a/tests/scripts/test_send_follow_up_texts.py
+++ b/tests/scripts/test_send_follow_up_texts.py
@@ -32,9 +32,7 @@ class SendFollowUpTextsTestCase(unittest.TestCase):
         self._in_cutoff.text_date = datetime.utcnow() - timedelta(days=cutoff_days,
                                                                   hours=3)
 
-        # Our cutoff is one week.
         self._out_cutoff = Texter('OUT_CUTOFF')
-        self._out_cutoff.text_date = datetime.utcnow()
 
         db.session.add_all([self._in_cutoff, self._out_cutoff])
         db.session.commit()
@@ -63,3 +61,18 @@ class SendFollowUpTextsTestCase(unittest.TestCase):
         send_follow_up_texts()
 
         self.assertEqual(start_count - 1, len(Texter.query.all()))
+
+    def test_sends_with_custom_cutoff(self):
+        """
+        We can manually configure the cutoff date, and we want to check that it
+        works appropriately if we do.
+        """
+        new_texter = Texter('SECOND_OUT_CUTOFF')
+        db.session.add(new_texter)
+        db.session.commit()
+
+        previous_texts = get_text_class().messages_sent
+        send_follow_up_texts(cutoff_days=0)
+
+        # For the `self._out_cutoff` user and the new one we just created.
+        self.assertEqual(previous_texts + 2, get_text_class().messages_sent)

--- a/text_support/scripts/send_follow_up_texts.py
+++ b/text_support/scripts/send_follow_up_texts.py
@@ -17,19 +17,22 @@ from ..text import get_follow_up_body, get_text_class, TextException
 
 Stats = namedtuple('Stats', ['successful', 'failed'])
 
-def main():
+def main(cutoff_days=environment_config().CUTOFF_DAYS):
     """
     Send texts to all Texters who texted in a week ago, encouraging them to
     follow up with their friend.
 
     Delete the texter from the database.
 
+    Args:
+        cutoff_days(int): The number of days ago for which we will send a follow
+        up text.
+
     Returns:
         Stats : The Stats pertaining to the success of this script.
     """
     now = datetime.utcnow()
 
-    cutoff_days = environment_config().CUTOFF_DAYS
     cutoff_date_start = now - timedelta(days=cutoff_days + 1)
     cutoff_date_end = now - timedelta(days=cutoff_days)
 


### PR DESCRIPTION
Adds a `force_follow_up_texts` command to `manage.py` which sends follow
up texts to all texters within the last day. This feature will be used
for testing our deploy on Heroku.