### PR TITLE
Add favicon

### DIFF
--- a/text_support/templates/layout.html
+++ b/text_support/templates/layout.html
@@ -6,6 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!--[if lte IE 8]><script src="{{ url_for('static', filename='js/html5/shiv.js') }}"></script><![endif]-->
+    <link rel="shortcut icon" type="image/png" href="http://hackmh.com/images/hackMH_favicon.png"/>
     <!-- Version with the Git commit hash from the previous commit and make it
     so `?` and `=` are not escaped. -->
     <link rel="stylesheet" href="{{ url_for('static',


### PR DESCRIPTION
Add the hackMH logo as a favicon. We reference the favicon on the hackMH
website to keep them all unified.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>